### PR TITLE
Fix: "invalid string parameter" in nightlies

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -87,7 +87,7 @@ STR_TRACK_GRASS_UNDERLAY:Grass underlay for fences
 STR_PARAM_PYLONS_TIMED:Enable chronological change of pylons
 STR_PARAM_PYLONS_TIMED_DESC:From old wooden tram pylons (~1909) to metal (1910~1959) to modern concrete pylons (1960~). Selecting any other option below will overwrite this setting.
 
-STR_PARAM_PYLONS:Select {STRING} {STRING}pylons style
+STR_PARAM_PYLONS:Select {STRING} pylons style
 STR_PARAM_PYLONS_DESC:Modern - concrete and slab tracks.{}"Plain metal", "Concrete" and "xUSSR" pylons have different graphics for DC,AC and AC/DC tracks
 STR_PARAM_PYLON_0:Wooden pylons
 STR_PARAM_PYLON_1:Plain metal pylons
@@ -141,7 +141,7 @@ STR_DUAL_G:Dual Gauge
 STR_SHIN:Standard High-Speed
 STR_MAGLEV:SC-Maglev
 STR_GUIDEWAY:Guideway
-STR_UNIVERSAL_1:Universal Underground 
+STR_UNIVERSAL_1:Universal Underground
 STR_INDUSTRIAL:Industrial
 
 STR_DECO_INVIS:Invisible Track

--- a/lang/simplified_chinese.lng
+++ b/lang/simplified_chinese.lng
@@ -88,7 +88,7 @@ STR_TRACK_GRASS_UNDERLAY:栅栏草地底层
 STR_PARAM_PYLONS_TIMED:动态接触网杆
 STR_PARAM_PYLONS_TIMED_DESC:启用时，接触网杆将按年代变化，从木质杆（—1909），至金属杆（1910—1959），最后到现代混凝土杆（1960—）。在下方设置项中选择任何其他选项将覆盖此设置。
 
-STR_PARAM_PYLONS:选择{STRING}{STRING}接触网杆样式
+STR_PARAM_PYLONS:选择{STRING}接触网杆样式
 STR_PARAM_PYLONS_DESC:现代 — 混凝土与预制板轨道。{}“金属”、“混凝土”与“xUSSR 式混凝土”选项会为交流、直流与交流/直流轨道显示不同的图像。
 STR_PARAM_PYLON_0:木质
 STR_PARAM_PYLON_1:金属


### PR DESCRIPTION
`STR_PARAM_PYLONS` has an extra `{STRING}` control code, which causes the nightlies to show "(invalid parameter)" in the parameters page.

Removed the extra control code.

![image](https://github.com/user-attachments/assets/843aaed1-cae7-4161-b2dd-344b311a6be1)
