### PR TITLE
fix: invalid parameters in captions

### DIFF
--- a/src/rails/dualgauge/dualgauge_1.pnml
+++ b/src/rails/dualgauge/dualgauge_1.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_dualgauge_1, 33) {
     property {
         label:                          "dAAN";
-        introduction_date:              date(1850, 1, 1);               
+        introduction_date:              date(1850, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_DUAL_G)),string(STR_WOODEN_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_DUAL_G)),string(STR_WOODEN_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_DUAL_G)),string(STR_WOODEN_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_DUAL_G)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_DUAL_G));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_DUAL_G)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_DUAL_G));
+        new_engine_text:                string(STR_DUAL_G);
+        autoreplace_text:               string(STR_REPLACE,string(STR_DUAL_G));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/narrow/narrow_ne_0.pnml
+++ b/src/rails/narrow/narrow_ne_0.pnml
@@ -1,13 +1,13 @@
   item(FEAT_RAILTYPES, track_narrow_ne_0, 00) {
     property {
         label:                          "NAAN";
-        introduction_date:              date(1850, 1, 1);               
+        introduction_date:              date(1850, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_OLD));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_OLD));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_OLD));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_NARROW)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_NARROW));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_NARROW)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_NARROW));
+        new_engine_text:                string(STR_NARROW);
+        autoreplace_text:               string(STR_REPLACE,string(STR_NARROW));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/narrow/narrow_ne_1.pnml
+++ b/src/rails/narrow/narrow_ne_1.pnml
@@ -1,13 +1,13 @@
   item(FEAT_RAILTYPES, track_narrow_ne_1, 01) {
     property {
         label:                          "NBAN";
-        introduction_date:              date(1900, 1, 1);               
+        introduction_date:              date(1900, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_WOODEN_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_WOODEN_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_WOODEN_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_NARROW)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_NARROW));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_NARROW)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_NARROW));
+        new_engine_text:                string(STR_NARROW);
+        autoreplace_text:               string(STR_REPLACE,string(STR_NARROW));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/narrow/narrow_ne_2.pnml
+++ b/src/rails/narrow/narrow_ne_2.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_narrow_ne_2, 02) {
     property {
         label:                          "NCAN";
-        introduction_date:              date(1950, 1, 1);     
+        introduction_date:              date(1950, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_CONCRETE_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_CONCRETE_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_CONCRETE_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_NARROW)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_NARROW));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_NARROW)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_NARROW));
+        new_engine_text:                string(STR_NARROW);
+        autoreplace_text:               string(STR_REPLACE,string(STR_NARROW));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/narrow/narrow_ne_3.pnml
+++ b/src/rails/narrow/narrow_ne_3.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_narrow_ne_3, 03) {
     property {
         label:                          "NDAN";
-        introduction_date:              date(1972, 1, 1);               
+        introduction_date:              date(1972, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_SLAB_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_SLAB_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_NARROW)),string(STR_SLAB_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_NARROW)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_NARROW));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_NARROW)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_NARROW));
+        new_engine_text:                string(STR_NARROW);
+        autoreplace_text:               string(STR_REPLACE,string(STR_NARROW));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/standard/standard_ne_0.pnml
+++ b/src/rails/standard/standard_ne_0.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_standard_ne_0, 15) {
     property {
         label:                          "RAIL";
-        introduction_date:              date(1850, 1, 1);               
+        introduction_date:              date(1850, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_OLD));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_OLD));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_OLD));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_STANDARD)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_STANDARD));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_STANDARD)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_STANDARD));
+        new_engine_text:                string(STR_STANDARD);
+        autoreplace_text:               string(STR_REPLACE,string(STR_STANDARD));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/standard/standard_ne_1.pnml
+++ b/src/rails/standard/standard_ne_1.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_standard_ne_1, 16) {
     property {
         label:                          "SAAN";
-        introduction_date:              date(1900, 1, 1);               
+        introduction_date:              date(1900, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_WOODEN_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_WOODEN_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_WOODEN_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_STANDARD)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_STANDARD));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_STANDARD)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_STANDARD));
+        new_engine_text:                string(STR_STANDARD);
+        autoreplace_text:               string(STR_REPLACE,string(STR_STANDARD));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;

--- a/src/rails/standard/standard_ne_2.pnml
+++ b/src/rails/standard/standard_ne_2.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_standard_ne_2, 17) {
     property {
         label:                          "SBAN";
-        introduction_date:              date(1950, 1, 1);               
+        introduction_date:              date(1950, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_CONCRETE_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_CONCRETE_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_CONCRETE_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_STANDARD)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_STANDARD));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_STANDARD)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_STANDARD));
+        new_engine_text:                string(STR_STANDARD);
+        autoreplace_text:               string(STR_REPLACE,string(STR_STANDARD));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;
@@ -21,7 +21,7 @@ item(FEAT_RAILTYPES, track_standard_ne_2, 17) {
         compatible_railtype_list: [tt_standard_ALL];
         powered_railtype_list: [tt_standard_ALL];
     }
-    
+
     graphics {
         gui:                            sw_concrete_ne_gui;
         track_overlay:                  sw_1435_overlay;

--- a/src/rails/standard/standard_ne_3.pnml
+++ b/src/rails/standard/standard_ne_3.pnml
@@ -1,13 +1,13 @@
 item(FEAT_RAILTYPES, track_standard_ne_3, 18) {
     property {
         label:                          "SCAN";
-        introduction_date:              date(1972, 1, 1);               
+        introduction_date:              date(1972, 1, 1);
         name:                           string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_SLAB_TIES));
         menu_text:                      string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_SLAB_TIES));
         toolbar_caption:                string(STR_ADDIT,string(STR_TRACK,string(STR_STANDARD)),string(STR_SLAB_TIES));
-        build_window_caption:           string(STR_PURCHASE,string(STR_CONCAT_2,string(STR_STANDARD)));
-        new_engine_text:                string(STR_CONCAT_2,string(STR_STANDARD));
-        autoreplace_text:               string(STR_REPLACE,string(STR_CONCAT_2,string(STR_STANDARD)));
+        build_window_caption:           string(STR_PURCHASE,string(STR_STANDARD));
+        new_engine_text:                string(STR_STANDARD);
+        autoreplace_text:               string(STR_REPLACE,string(STR_STANDARD));
 
         station_graphics:               RAILTYPE_STATION_NORMAL;
         acceleration_model:             ACC_MODEL_RAIL;
@@ -21,7 +21,7 @@ item(FEAT_RAILTYPES, track_standard_ne_3, 18) {
         compatible_railtype_list: [tt_standard_ALL];
         powered_railtype_list: [tt_standard_ALL];
     }
-    
+
     graphics {
         gui:                            sw_urban_ne_gui;
         track_overlay:                  sw_1435_overlay_snow_1;


### PR DESCRIPTION
Judging by the decompiled result there seem to be lots of `substring` paremeters, in which they shouldn't appear in the NewGRF since strings shouldn't take parameters at run time. It is caused by incorrect string concatenation. This PR fixes the problem by removing the concat part.

Searched using regex pattern `string\s*\(\s*STR_CONCAT_2\s*,\s*(string\s*\(\s*[^()]*\s*\))\s*\)`, and there doesn't seem to be any more `substring` parameters in the new decompiled file.
